### PR TITLE
Add tests with multiple `bind` chains to cover remaining code.

### DIFF
--- a/test/spec/effect.spec.exs
+++ b/test/spec/effect.spec.exs
@@ -153,4 +153,11 @@ defmodule Test.Effects do
     end
   end
 
+  describe "interpreter" do
+    it "should handle sequenced effects" do
+      effect = inc ~> inc ~> inc
+      expect 3 |> interp(effect) |> to(eq 6)
+    end
+  end
+
 end


### PR DESCRIPTION
Previously a certain branch of code was missed due to too short an internal queue length of effects. This branch is now covered.
